### PR TITLE
fix: mixed config file and command line flag

### DIFF
--- a/gcg.go
+++ b/gcg.go
@@ -73,8 +73,7 @@ The generator use only Pull Requests.`,
 
 	usedCmd, err := flag.GetCommand()
 	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	if _, err := flag.Parse(usedCmd); err != nil {
@@ -82,7 +81,6 @@ The generator use only Pull Requests.`,
 			os.Exit(0)
 		}
 		log.Fatalf("Error parsing command: %s\n", err)
-		os.Exit(1)
 	}
 
 	s := staert.NewStaert(rootCmd)

--- a/gcg.go
+++ b/gcg.go
@@ -71,6 +71,20 @@ The generator use only Pull Requests.`,
 
 	flag.AddCommand(versionCmd)
 
+	usedCmd, err := flag.GetCommand()
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+
+	if _, err := flag.Parse(usedCmd); err != nil {
+		if err == pflag.ErrHelp {
+			os.Exit(0)
+		}
+		log.Fatalf("Error parsing command: %s\n", err)
+		os.Exit(1)
+	}
+
 	s := staert.NewStaert(rootCmd)
 
 	// init TOML source


### PR DESCRIPTION
### Description

This PR allows user to mixed config file and flag

Command used:
```console
gcg \
--base-branch="v1.0" --previous-ref="v1.0.0" \
--current-ref="v1.0" --future-ref-name="v1.0.1" \
--token=$GCG_GITHUB_TOKEN --config-file="private-gcg.toml"
```

TOML file:
```toml
Owner = "containous"
RepositoryName = "powpow"

OutputType = "file"
FileName = "private_changelog.md"

ThresholdPreviousRef = 10
ThresholdCurrentRef = 10

Debug = true
DisplayLabel = true

LabelExcludes = [""]
LabelEnhancement = "kind/enhancement"
LabelDocumentation = "area/documentation"
LabelBug = "kind/bug/fix"

[DisplayLabelOptions]
  FilteredPrefixes = ["area/", "platform/"]
  ExcludedSuffixes = ["documentation"]
  TrimmedPrefixes = ["area/"]
```

Output command before the fix
```console
2019/02/07 09:36:24 Error: owner is mandatory
```

Output command after the fix
```console
2019/02/07 09:37:00 Run GCG command with config : &{ConfigFile:private-gcg.toml Owner:containous RepositoryName:powpow GitHubToken:XXXXXXXXX OutputType:file FileName:private_changelog.md CurrentRef:v1.0 PreviousRef:v1.0.0 BaseBranch:v1.0 FutureCurrentRefName:v1.0.1 ThresholdPreviousRef:10 ThresholdCurrentRef:10 Debug:true DisplayLabel:true LabelExcludes:[] LabelEnhancement:kind/enhancement LabelDocumentation:area/documentation LabelBug:kind/bug/fix DisplayLabelOptions:0xc0000e0400 TemplateFile:}
2019/02/07 09:37:00 Run GCG command with config : &{FilteredPrefixes:[area/ platform/] ExcludedPrefixes:[] FilteredSuffixes:[] ExcludedSuffixes:[documentation] TrimmedPrefixes:[area/]}
2019/02/07 09:37:01 type:pr is:merged repo:containous/powpow base:v1.0 merged:2019-01-30T12:32:14Z..2019-02-06T15:48:14Z
```