### PR TITLE
doc: fix URL of gitgraph.js

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -197,4 +197,4 @@ gcg \
 
 == References
 
-Images generated with link:http://gitgraphjs.com/[gitgraphjs]
+Images generated with link:https://www.nicoespeon.com/gitgraph.js/[gitgraphjs]


### PR DESCRIPTION
- gitgraphjs.com is no longer operated by the author
- use URL from the gitgraph.js project page (https://github.com/nicoespeon/gitgraph.js/)